### PR TITLE
Fixed Incorrect tag count when filters active with group mismatches

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 
 export default [
-    { ignores: ["dist"] },
+    { ignores: ["dist", "backend/public"] },
     {
         files: ["**/*.{js,jsx}"],
         languageOptions: {

--- a/src/pages/Playfrens.jsx
+++ b/src/pages/Playfrens.jsx
@@ -4,7 +4,6 @@ import { Navigate } from "react-router-dom";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as Avatar from "@radix-ui/react-avatar";
 import * as Popover from "@radix-ui/react-popover";
-import { BsChatHeartFill } from "react-icons/bs";
 import {
     MdChevronRight,
     MdClose,

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -475,16 +475,22 @@ export class DataStore {
         t.totalGamesCount = [...this.allGames.values()].filter((game) => game.hasTag(t)).length;
     }
 
-    updateAllTagFilteredGamesCounters(filteredGames) {
+    /** @param {(game: GameObject, tag: TagObject) => boolean} doesGameQualifyForTag - also know as FilterStore.doesGameQualifyForTag */
+    updateAllTagFilteredGamesCounters(doesGameQualifyForTag) {
         this.allTagsFlatForEach(
-            (t) => (t.filteredGamesCount = filteredGames.filter((game) => game.hasTag(t)).length),
+            (t) =>
+                (t.filteredGamesCount = [...this.allGames.values()].filter((game) =>
+                    doesGameQualifyForTag(game, t),
+                ).length),
         );
     }
 
-    updateTagFilteredGamesCounter(tag, filteredGames) {
-        // used whenever adding/removing a tag from a game. not the prettiest, but is efficient
+    /** @param {(game: GameObject, tag: TagObject) => boolean} doesGameQualifyForTag - used whenever adding/removing a tag from a game. not the prettiest, but is efficient */
+    updateTagFilteredGamesCounter(tag, doesGameQualifyForTag) {
         const t = this.allTags[tag.type].get(tag.id);
-        t.filteredGamesCount = filteredGames.filter((game) => game.hasTag(t)).length;
+        t.filteredGamesCount = [...this.allGames.values()].filter((game) =>
+            doesGameQualifyForTag(game, t),
+        ).length;
     }
 
     addGame(title, coverImageURL, coverThumbURL, sortingTitle, storeType, storeID, sgdbID) {

--- a/src/stores/FilterStore.js
+++ b/src/stores/FilterStore.js
@@ -147,13 +147,24 @@ class FilterStore {
     }
 
     doesGamePassFilters(game) {
-        if (this.search) {
-            if (!game.title.toLowerCase().includes(this.search.toLowerCase())) {
-                return false;
-            }
-        }
+        if (this.search && !game.title.toLowerCase().includes(this.search.toLowerCase()))
+            return false;
 
         return game.parties.some((party) => this.doesPartyPassFilters(party));
+    }
+
+    /**
+     * Similar to {@link doesGamePassFilters}, but also requires the matching party to have `tag`, so a
+     * game isn't counted for `tag` just because an unrelated party pass the active filters.
+     * @param {import("@/models").GameObject} game
+     * @param {TagObject} tag
+     * @returns {boolean}
+     */
+    doesGameQualifyForTag(game, tag) {
+        if (this.search && !game.title.toLowerCase().includes(this.search.toLowerCase()))
+            return false;
+
+        return game.parties.some((party) => this.doesPartyPassFilters(party) && party.hasTag(tag));
     }
 
     /**
@@ -196,12 +207,17 @@ export const globalFilterStore = filterStore;
 // filtered games is in the FilterStore, so this provides it to the DataStore, only when filteredGames/allGames changes
 reaction(
     () => filterStore.filteredGames,
-    (filteredGames) => globalDataStore.updateAllTagFilteredGamesCounters(filteredGames),
+    () =>
+        globalDataStore.updateAllTagFilteredGamesCounters((game, tag) =>
+            filterStore.doesGameQualifyForTag(game, tag),
+        ),
     { fireImmediately: true },
 );
 // and this is a wrapper function to update the other cases that can change this counter;
 // used when adding/removing a tag from a game
 export function updateTagBothGameCounters(tag) {
-    globalDataStore.updateTagFilteredGamesCounter(tag, filterStore.filteredGames);
+    globalDataStore.updateTagFilteredGamesCounter(tag, (game, t) =>
+        filterStore.doesGameQualifyForTag(game, t),
+    );
     globalDataStore.updateTagTotalGamesCounter(tag);
 }


### PR DESCRIPTION
I've pushed a few changes that  inside this commit 95be1d0ac556608ec0b5a2c6f783bfedbb573208 contains the fix regarding the incorrect tag.

Example: I select `Person A` and `Person B`. I see there are 2 Ready To Start games, but when I click it, I only see one. That’s because `Game A` has `Person A` and `Person B` in one group, but that status of `Person A` is from another group of `Person B`.

This solves by showing the correct number count to match the comparison.