### PR TITLE
Board Partial Save Part 2

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -59,6 +59,49 @@ export function saveToStorage(key, value) {
     localStorage.setItem(key, JSON.stringify(value, null, 4));
 }
 
+/**
+ * Strips class or JSON-like object, and turns it into a generic object.
+ *
+ * @param {*} value
+ * @returns {*} a plain, detached clone containing just the data
+ *
+ * @example
+ * class Party {
+ *     tagIDs = { friend: new Set(["example"]) };
+ * }
+ * const party = new Party();
+ * console.log(party); // Party { tagIDs: [Getter/Setter] }
+ * toPlainObject(party); // { tagIDs: { friend: ["example"] } }
+ */
+export function toPlainObject(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Deep equal that doesn't care about object key order, unlike a JSON.stringify which does care.
+ *
+ * @param {*} a
+ * @param {*} b
+ * @returns {boolean} true if a and b are structurally equal
+ *
+ * @example
+ * deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 }); // true (JSON.stringify would say false, different key order)
+ * deepEqual({ a: 1 }, { a: 2 }); // false
+ */
+export function deepEqual(a, b) {
+    if (a === b) return true;
+    if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+    if (Array.isArray(a) !== Array.isArray(b)) return false;
+    if (Array.isArray(a))
+        return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    return (
+        aKeys.length === bKeys.length &&
+        aKeys.every((key) => Object.hasOwn(b, key) && deepEqual(a[key], b[key]))
+    );
+}
+
 export function deleteItemFromArray(arr, item) {
     const index = arr.indexOf(item);
     if (index > -1) arr.splice(index, 1);

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -251,7 +251,8 @@ export async function coverToThumb(coverURL) {
 }
 
 /**
- * Checks if an object's fields differ from provided values
+ * Checks if an object's fields differ from provided values. A key in partial that doesn't exist
+ * on obj is ignored - there's nothing to compare it to.
  *
  * @template {object} T
  * @param {T} obj - The object we are checking
@@ -262,14 +263,15 @@ export async function coverToThumb(coverURL) {
  * const obj = { icon: "a", type: "b" };
  * const p1 = { icon: "x" };
  * const p2 = { icon: "a" };
- * const p3 = { bad_key_icon: "a" };
- * shouldUPdateObject(obj, p1); // true
- * shouldUPdateObject(obj, p2); // false (matching values)
- * shouldUPdateObject(obj, p3); // false (nothing to compare)
+ * const p3 = { icon_small: "a" };
+ * shouldUpdateObject(obj, p1); // true
+ * shouldUpdateObject(obj, p2); // false (matching values)
+ * shouldUpdateObject(obj, p3); // false (nothing to compare)
  */
 export function shouldUpdateObject(obj, partial = {}) {
     return Object.entries(partial).some(([key, value]) => {
-        return obj[key] !== value;
+        if (!Object.hasOwn(obj, key)) return false;
+        return !deepEqual(obj[key], value);
     });
 }
 
@@ -285,9 +287,10 @@ export function updateObject(obj, partial = {}) {
     let updated = false;
 
     for (const key of /** @type {Array<keyof T>} */ (Object.keys(partial))) {
-        const value = partial[key];
+        if (!Object.hasOwn(obj, key)) continue;
 
-        if (obj[key] !== value) {
+        const value = partial[key];
+        if (!deepEqual(obj[key], value)) {
             obj[key] = value;
             updated = true;
         }

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -18,6 +18,7 @@ import { globalSettingsStore, settingsStorageKey, userStore } from "@/stores";
 import {
     coverToThumb,
     debounce,
+    deepEqual,
     deleteItemFromArray,
     ensureUniqueName,
     loadFromStorage,
@@ -28,6 +29,7 @@ import {
     toastError,
     toastInfo,
     toastSuccess,
+    toPlainObject,
     updateObject,
 } from "@/Utils";
 import { SortingReaction } from "./SortingReaction.js";
@@ -121,22 +123,69 @@ export class DataStore {
             toastError(error);
         }
 
-        // keep localStorage and the backend in sync, per key
+        // keep the backend in sync, per key
         const watchAndSync = (storageKey, item) => {
             reaction(
                 () => JSON.stringify(item),
+                () => this.#syncKeyToBackend(storageKey, item),
+            );
+        };
+        watchAndSync(storageKeys.reminders, this.allReminders);
+        watchAndSync(storageKeys.tagsCustomOrders, this.tagsCustomOrders);
+
+        const watchAndSyncCollection = (storageKey, map) => {
+            let lastSynced = [...map.entries()].map(([id, v]) => [id, toPlainObject(v)]);
+
+            reaction(
+                () => JSON.stringify(map), // rechecks below whenever anything in the map changes
                 () => {
-                    saveToStorage(storageKey, item);
-                    this.#syncKeyToBackend(storageKey, item);
+                    if (!this.#isHydrated) return;
+
+                    const current = [...map.entries()];
+                    const lastByID = new Map(lastSynced);
+
+                    // same amount of entries, and every current ID was already known -> nothing added/removed
+                    const sameIDs =
+                        current.length === lastSynced.length &&
+                        current.every(([id]) => lastByID.has(id));
+
+                    // which entries actually differ - only worth checking if membership is unchanged
+                    const changed = sameIDs
+                        ? current.filter(
+                              // postgres doesn't preserve key order, so a plain string compare would call every entry "changed"
+                              ([id, v]) => !deepEqual(toPlainObject(v), lastByID.get(id)),
+                          )
+                        : [];
+
+                    // re-order or only a non-persisted field changed (like a tag's game count), nothing to send
+                    if (sameIDs && changed.length === 0) return;
+
+                    if (sameIDs && changed.length === 1) {
+                        // exactly one entry changed, so patch just that array slot
+                        const [id, value] = changed[0];
+                        const snapshot = toPlainObject(value);
+                        const index = lastSynced.findIndex(([lastID]) => lastID === id);
+                        debounce(
+                            this.#syncTimers,
+                            `${storageKey}::${id}`, // own timer per entry, so editing two things doesn't cancel either update
+                            () => updateBoard([storageKey, index], [id, snapshot]).catch(() => {}),
+                            100,
+                        );
+                        lastSynced[index] = [id, snapshot]; // remember what we just sent
+                        return;
+                    }
+
+                    // an entry was added/removed, or several changed at once, then just resend everything
+                    const snapshot = current.map(([id, v]) => [id, toPlainObject(v)]);
+                    this.#syncKeyToBackend(storageKey, snapshot);
+                    lastSynced = snapshot;
                 },
             );
         };
-        watchAndSync(storageKeys[tT.friend], this.allTags[tT.friend]);
-        watchAndSync(storageKeys[tT.category], this.allTags[tT.category]);
-        watchAndSync(storageKeys[tT.status], this.allTags[tT.status]);
-        watchAndSync(storageKeys.games, this.allGames);
-        watchAndSync(storageKeys.reminders, this.allReminders);
-        watchAndSync(storageKeys.tagsCustomOrders, this.tagsCustomOrders);
+        watchAndSyncCollection(storageKeys[tT.friend], this.allTags[tT.friend]);
+        watchAndSyncCollection(storageKeys[tT.category], this.allTags[tT.category]);
+        watchAndSyncCollection(storageKeys[tT.status], this.allTags[tT.status]);
+        watchAndSyncCollection(storageKeys.games, this.allGames);
     }
 
     // Debounced partial update (update_board_path) instead of re-uploading the whole board.


### PR DESCRIPTION
This one has working granular update system that goes deeper, it will know correctly which part of the board was updated and replaces pretty much only the game.

This has reduced response time more than hundred times for boards with more than 100+ games, even to a point that data being sent is way faster now on the network tab (previously we were being reported that its slow, 500ms or more to finish the request).

In general:
* Added deepEqua()l - this compares everything except their key order.
* toPlainObject() - turns a class, or json-like into a plain object, this strips all class features, get/setter and leaving purely data.
* Updated some old utils since they have potential to be also changed.
* Now updates specifically the game that was modified by going one layer deeper `["allgames"]` -> `["allgames", 2]` (2 is an index of a game in the board).
* Same applies to editing info of friends.