### PR TITLE
Authentication Cache

### DIFF
--- a/backend/auth/SupabaseSessionStore.js
+++ b/backend/auth/SupabaseSessionStore.js
@@ -5,7 +5,7 @@ const DEFAULT_PRUNE_INTERVAL = 15 * 60 * 1000; // 15 Minutes
 
 // Short cache for get(), since it runs on every request.
 // destroy() clears entries immediately so logout isn't delayed.
-const SESSION_CACHE_LIFETIME_MS = 30 * 1000; // 30 seconds
+const SESSION_CACHE_LIFETIME_SECS = 120; // 2 minutes
 const sessionCache = new Map(); // sid -> { sess, expiresAt }
 
 // Sweeps expired entries on every write instead of a timer, so lapsed sessions don't last forever.
@@ -49,7 +49,7 @@ export class SupabaseSessionStore extends Store {
                 pruneSessionCache();
                 sessionCache.set(sid, {
                     sess: data.sess,
-                    expiresAt: Date.now() + SESSION_CACHE_LIFETIME_MS,
+                    expiresAt: Date.now() + SESSION_CACHE_LIFETIME_SECS * 1000,
                 });
                 callback(null, data.sess);
             }, callback);

--- a/backend/auth/SupabaseSessionStore.js
+++ b/backend/auth/SupabaseSessionStore.js
@@ -3,6 +3,19 @@ import { supabase } from "../supabaseClient.js";
 
 const DEFAULT_PRUNE_INTERVAL = 15 * 60 * 1000; // 15 Minutes
 
+// Short cache for get(), since it runs on every request.
+// destroy() clears entries immediately so logout isn't delayed.
+const SESSION_CACHE_LIFETIME_MS = 30 * 1000; // 30 seconds
+const sessionCache = new Map(); // sid -> { sess, expiresAt }
+
+// Sweeps expired entries on every write instead of a timer, so lapsed sessions don't last forever.
+function pruneSessionCache() {
+    const now = Date.now();
+    for (const [sid, entry] of sessionCache) {
+        if (entry.expiresAt <= now) sessionCache.delete(sid);
+    }
+}
+
 /**
  * `express-session` Store backed by Supabase
  */
@@ -22,6 +35,9 @@ export class SupabaseSessionStore extends Store {
     }
 
     get(sid, callback) {
+        const cached = sessionCache.get(sid);
+        if (cached && cached.expiresAt > Date.now()) return callback(null, cached.sess);
+
         supabase
             .from("sessions")
             .select("sess, expires")
@@ -30,6 +46,11 @@ export class SupabaseSessionStore extends Store {
             .then(({ data, error }) => {
                 if (error) return callback(error);
                 if (!data || new Date(data.expires) <= new Date()) return callback(null, null);
+                pruneSessionCache();
+                sessionCache.set(sid, {
+                    sess: data.sess,
+                    expiresAt: Date.now() + SESSION_CACHE_LIFETIME_MS,
+                });
                 callback(null, data.sess);
             }, callback);
     }
@@ -46,6 +67,7 @@ export class SupabaseSessionStore extends Store {
     }
 
     destroy(sid, callback) {
+        sessionCache.delete(sid);
         supabase
             .from("sessions")
             .delete()
@@ -57,4 +79,3 @@ export class SupabaseSessionStore extends Store {
         this.set(sid, session, callback);
     }
 }
-

--- a/backend/auth/passport.js
+++ b/backend/auth/passport.js
@@ -6,6 +6,23 @@ import { Strategy as DiscordStrategy } from "passport-discord";
 import { resolveBaseURL } from "../utils.js";
 import { supabase } from "../supabaseClient.js";
 
+// Short cache for deserializeUser, since it runs on every authenticated request.
+const USER_CACHE_LIFETIME_MS = 30 * 1000; // 30 seconds
+const userCache = new Map(); // userId -> { user, expiresAt }
+
+// Call after deleting a user's row, so other active sessions for the account stop working immediately.
+export function invalidateUserCache(userId) {
+    userCache.delete(userId);
+}
+
+// Removes expired entries on every write instead of a timer, so lapsed users don't last forever.
+function pruneUserCache() {
+    const now = Date.now();
+    for (const [id, entry] of userCache) {
+        if (entry.expiresAt <= now) userCache.delete(id);
+    }
+}
+
 async function upsertUser(profile, provider) {
     const providerId = (() => {
         switch (provider) {
@@ -124,6 +141,9 @@ async function upsertUser(profile, provider) {
 export function configurePassport() {
     passport.serializeUser((user, done) => done(null, user.id));
     passport.deserializeUser(async (id, done) => {
+        const cached = userCache.get(id);
+        if (cached && cached.expiresAt > Date.now()) return done(null, cached.user);
+
         const { data: user, error } = await supabase
             .from("users")
             .select("*")
@@ -131,6 +151,8 @@ export function configurePassport() {
             .single();
         // No rows? Then account was deleted, treat as logged out instead of erroring.
         if (error) return done(error.code === "PGRST116" ? null : error, false);
+        pruneUserCache();
+        userCache.set(id, { user, expiresAt: Date.now() + USER_CACHE_LIFETIME_MS });
         done(null, user);
     });
 

--- a/backend/auth/passport.js
+++ b/backend/auth/passport.js
@@ -7,7 +7,7 @@ import { resolveBaseURL } from "../utils.js";
 import { supabase } from "../supabaseClient.js";
 
 // Short cache for deserializeUser, since it runs on every authenticated request.
-const USER_CACHE_LIFETIME_MS = 30 * 1000; // 30 seconds
+const USER_CACHE_LIFETIME_SECS = 120; // 2 minutes
 const userCache = new Map(); // userId -> { user, expiresAt }
 
 // Call after deleting a user's row, so other active sessions for the account stop working immediately.
@@ -152,7 +152,7 @@ export function configurePassport() {
         // No rows? Then account was deleted, treat as logged out instead of erroring.
         if (error) return done(error.code === "PGRST116" ? null : error, false);
         pruneUserCache();
-        userCache.set(id, { user, expiresAt: Date.now() + USER_CACHE_LIFETIME_MS });
+        userCache.set(id, { user, expiresAt: Date.now() + USER_CACHE_LIFETIME_SECS * 1000 });
         done(null, user);
     });
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -4,6 +4,7 @@ import rateLimit from "express-rate-limit";
 import { Response } from "../response.js";
 import { supabase } from "../supabaseClient.js";
 import { requireAuth } from "../auth/requireAuth.js";
+import { invalidateUserCache } from "../auth/passport.js";
 import { strToBool } from "../utils.js";
 
 const router = Router();
@@ -192,6 +193,7 @@ async function deleteAccount(req, res) {
     }
     // 204 is the expected response for deleting data
     if (responseStatus === 204) {
+        invalidateUserCache(req.user.id); // so other active sessions for this account stop working immediately
         req.session.destroy((err) => {
             if (err) return respondError(err);
             res.clearCookie("connect.sid");


### PR DESCRIPTION
When doing server-sided requests users must request to see if they are valid and authenticated per request, this as a result slows requests down by twice the amount which makes request/response slow because of verification with supabase.

Instead this verification is done once and then persist for 30 seconds by caching it as a recent authenticity. 

This caching is valid until 30 seconds passed, signing out or account deletion.