### PR TITLE
Setting UI Imporvements and Label Clarity for Inputs

### DIFF
--- a/src/components/Dialogs/EditGameDialog.jsx
+++ b/src/components/Dialogs/EditGameDialog.jsx
@@ -1,7 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { Dialogs, globalDialogStore, useDataStore, useSettingsStore } from "@/stores";
-import { Button, Spinner, SearchSelect, InfoIcon } from "@/components";
+import { Button, Spinner, SearchSelect, InfoIcon, LabelBadge } from "@/components";
 import { DialogBase } from "./DialogRoot.jsx";
 import { createContext, useContext, useEffect, useState } from "react";
 import "./GamePageDialog.css";
@@ -172,7 +172,8 @@ export function EditGameDialog({ open, closeDialog, game = null }) {
                                 <>
                                     <label>
                                         Sorting Title
-                                        <InfoIcon message="Optional. Helps sort franchises with irregular titles. e.g. 'Metroid Zero Mission = Metroid 1, Super Metroid = Metroid 3'" />
+                                        <LabelBadge />
+                                        <InfoIcon message="Helps sort franchises with irregular titles. e.g. 'Metroid Zero Mission = Metroid 1, Super Metroid = Metroid 3'" />
                                     </label>
 
                                     <input

--- a/src/components/Dialogs/EditTagDialog.css
+++ b/src/components/Dialogs/EditTagDialog.css
@@ -1,3 +1,38 @@
+.steam-import-hint {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+    padding: 10px 14px;
+    background: var(--pf-bg-700);
+    border: var(--pf-border-700);
+    border-radius: 12px;
+
+    .steam-import-hint-icon {
+        flex: 0 0 auto;
+        font-size: 26px;
+        color: inherit;
+    }
+
+    p {
+        flex: 1 1 auto;
+        margin: 0;
+        color: var(--pf-fg-500);
+        font-size: 13px;
+        line-height: 1.4;
+    }
+
+    .btn {
+        flex: 0 0 auto;
+    }
+
+    .steam-import-hint-dismiss {
+        --icon-size: 24px;
+        flex: 0 0 auto;
+        font-size: 16px;
+    }
+}
+
 .icon-url-row {
     display: flex;
     align-items: stretch;
@@ -30,4 +65,3 @@
         }
     }
 }
-

--- a/src/components/Dialogs/EditTagDialog.jsx
+++ b/src/components/Dialogs/EditTagDialog.jsx
@@ -3,17 +3,27 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { DialogBase } from "./DialogRoot.jsx";
 import { TagObject, tagTypeStrings, FriendTagObject } from "@/models";
 import { Dialogs, globalDialogStore, useDataStore } from "@/stores";
-import { Button, FriendAvatar, InfoIcon } from "@/components";
+import { Button, FriendAvatar, IconButton, InfoIcon, LabelBadge } from "@/components";
 import { useState } from "react";
+import { BiLogoSteam } from "react-icons/bi";
+import { MdClose } from "react-icons/md";
+import { loadFromStorage, saveToStorage } from "@/Utils";
 import "./EditTagDialog.css";
+
+// Dismiss the Steam import hint on the client side only.
+const STEAM_FRIEND_HINT_DISMISSED_KEY = "friend-steam-hint-dismissed";
 
 // Both Edits existing tags, and Adds new ones - depending on whether a TagObject is provided, otherwise based on the newTagType
 export function EditTagDialog({ open, closeDialog, editingTag = null, addingTagOfType = null }) {
     const [advancedView, setAdvancedView] = useState(false);
     const [iconURLPreview, setIconURLPreview] = useState(editingTag?.iconURL ?? "");
+    const [hintDismissed, setHintDismissed] = useState(() =>
+        loadFromStorage(STEAM_FRIEND_HINT_DISMISSED_KEY, false),
+    );
     const isEdit = editingTag instanceof TagObject;
     const mode = isEdit ? "Edit" : "Add";
     const tagType = isEdit ? editingTag.type : addingTagOfType;
+    const isFriend = tagType === "friend";
     const title = mode + " " + tagTypeStrings[tagType].single;
     const description = isEdit
         ? "Editing " + editingTag.name
@@ -63,10 +73,29 @@ export function EditTagDialog({ open, closeDialog, editingTag = null, addingTagO
                 <Dialog.Description>{description}</Dialog.Description>
             </VisuallyHidden>
 
+            {isFriend && !isEdit && !hintDismissed && (
+                <div className="steam-import-hint">
+                    <BiLogoSteam className="steam-import-hint-icon" />
+                    <p>Have Steam friends? Import your whole list at once.</p>
+                    <Button variant="secondary" onClick={handleGoToImport}>
+                        Steam Import
+                    </Button>
+                    <IconButton
+                        className="steam-import-hint-dismiss"
+                        icon={<MdClose />}
+                        aria-label="Dismiss"
+                        onClick={() => {
+                            saveToStorage(STEAM_FRIEND_HINT_DISMISSED_KEY, true);
+                            setHintDismissed(true);
+                        }}
+                    />
+                </div>
+            )}
+
             <fieldset>
                 <label>
                     Name
-                    {tagType === "friend" && (
+                    {isFriend && (
                         <InfoIcon message="Just a name. It doesn't connect to any account." />
                     )}
                 </label>
@@ -76,16 +105,12 @@ export function EditTagDialog({ open, closeDialog, editingTag = null, addingTagO
                     defaultValue={editingTag?.name}
                     autoFocus
                 />
-                {tagType === "friend" && (advancedView || editingTag?.steamID) && (
+                {isFriend && (advancedView || editingTag?.steamID || editingTag?.iconURL) && (
                     <>
-                        <label>Steam ID</label>
-                        <input
-                            id="tagSteamIDInput"
-                            onKeyDown={saveOnEnter}
-                            defaultValue={editingTag?.steamID}
-                            autoFocus
-                        />
-                        <label>Icon URL</label>
+                        <label>
+                            Icon URL
+                            <LabelBadge />
+                        </label>
                         <div className="icon-url-row">
                             <input
                                 id="tagIconURLInput"
@@ -100,23 +125,21 @@ export function EditTagDialog({ open, closeDialog, editingTag = null, addingTagO
                                 ignoreDisplaySetting
                             />
                         </div>
+                        <label>
+                            Steam ID
+                            <LabelBadge />
+                        </label>
+                        <input
+                            id="tagSteamIDInput"
+                            onKeyDown={saveOnEnter}
+                            defaultValue={editingTag?.steamID}
+                        />
                     </>
                 )}
             </fieldset>
 
-            {tagType === "friend" && (
-                <div className="dialog-callout info" style={{ marginTop: "16px" }}>
-                    <p>
-                        You can import Steam friends{" "}
-                        <button className="link-like" onClick={handleGoToImport}>
-                            here
-                        </button>
-                    </p>
-                </div>
-            )}
-
             <div className="rx-dialog-footer">
-                {tagType === "friend" && !editingTag?.steamID && (
+                {isFriend && !editingTag?.steamID && !editingTag?.iconURL && (
                     <div className="footer-left">
                         <Button variant="ghost" onClick={() => setAdvancedView(!advancedView)}>
                             {advancedView ? "Simple" : "Advanced"}

--- a/src/components/Dialogs/SettingsDialog.css
+++ b/src/components/Dialogs/SettingsDialog.css
@@ -9,17 +9,20 @@
 
     .settings-tabs {
         gap: 8px;
+        border-bottom: var(--pf-border-300);
 
         button {
             width: fit-content;
             height: fit-content;
+            background: none;
             padding: 6px 12px;
             border-radius: 8px 8px 0 0;
             border-bottom: none;
+            outline: 1px solid var(--pf-bg-900);
             font-size: 13px;
 
             &[data-state="off"] {
-                background: none;
+                outline: none;
                 color: var(--pf-fg-700);
             }
         }

--- a/src/components/Dialogs/SettingsDialog.css
+++ b/src/components/Dialogs/SettingsDialog.css
@@ -1,31 +1,39 @@
 .settings-dialog {
     gap: 8px; /* between Title, Body, and Footer */
+    /* sized to match the Add Game dialog, so switching tabs doesn't resize the dialog; body scrolls instead */
+    width: 650px;
+    max-width: 85vw;
+    height: 825px;
+    max-height: 85vh;
+    overflow: hidden; /* overrides .rx-dialog's own scrolling; only .settings-dialog-body scrolls */
+
+    .settings-tabs {
+        gap: 8px;
+
+        button {
+            width: fit-content;
+            height: fit-content;
+            padding: 6px 12px;
+            border-radius: 8px 8px 0 0;
+            border-bottom: none;
+            font-size: 13px;
+
+            &[data-state="off"] {
+                background: none;
+                color: var(--pf-fg-700);
+            }
+        }
+    }
 
     .settings-dialog-body {
         display: flex;
         flex-direction: column;
         gap: 36px;
-    }
-
-    .setting {
-        display: flex;
-        flex-direction: column;
-        align-items: start;
-        gap: 4px;
-
-        h3 {
-            font-size: 16px;
-            line-height: 1;
-            font-weight: 500;
-            color: #f2f2f2;
-        }
-        p {
-            font-size: 14px;
-            color: var(--pf-fg-400);
-        }
-        & > *:not(h3) {
-            margin-left: 8px;
-        }
+        flex: 1;
+        min-height: 0; /* flex child won't shrink below its content height */
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+        padding-right: 4px; /* reserved space for the scrollbar-gutter */
     }
 
     .default-filters-buttons {

--- a/src/components/Dialogs/SettingsDialog.jsx
+++ b/src/components/Dialogs/SettingsDialog.jsx
@@ -1,22 +1,24 @@
+import { useState } from "react";
+import { observer } from "mobx-react-lite";
 import * as Dialog from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import * as RadioGroup from "@radix-ui/react-radio-group";
-import { Button, InfoIcon } from "@/components";
+import * as ToggleGroup from "@radix-ui/react-toggle-group";
+import { Button } from "@/components";
 import { DialogBase } from "./DialogRoot.jsx";
-import {
-    TagGameCounterOptions,
-    TagHoverGameHighlightOptions,
-    HideGameStoreButtonsOptions,
-    ShowMatureContentOptions,
-    FriendIconDisplayOptions,
-    useFilterStore,
-    useSettingsStore,
-} from "@/stores";
+import { SidebarTab } from "./SettingsDialog/SidebarTab.jsx";
+import { GamesGridTab } from "./SettingsDialog/GamesGridTab.jsx";
+import { FiltersTab } from "./SettingsDialog/FiltersTab.jsx";
 import "./SettingsDialog.css";
 
-export const SettingsDialog = ({ open, closeDialog }) => {
-    const settingsStore = useSettingsStore();
-    const filterStore = useFilterStore();
+const SettingsTabs = {
+    sidebar: { label: "Sidebar", Component: SidebarTab },
+    grid: { label: "Games Grid", Component: GamesGridTab },
+    filters: { label: "Filters", Component: FiltersTab },
+};
+
+export const SettingsDialog = observer(({ open, closeDialog }) => {
+    const [activeTab, setActiveTab] = useState(Object.keys(SettingsTabs)[0]);
+    const ActiveTabComponent = SettingsTabs[activeTab].Component;
 
     return (
         <DialogBase
@@ -29,131 +31,21 @@ export const SettingsDialog = ({ open, closeDialog }) => {
                 <Dialog.Description>Configure application settings</Dialog.Description>
             </VisuallyHidden>
 
+            <ToggleGroup.Root
+                type="single"
+                className="rx-toggle-group settings-tabs"
+                value={activeTab}
+                onValueChange={(tab) => tab && setActiveTab(tab)} // to avoid empty values
+            >
+                {Object.keys(SettingsTabs).map((tab) => (
+                    <ToggleGroup.Item value={tab} key={tab}>
+                        {SettingsTabs[tab].label}
+                    </ToggleGroup.Item>
+                ))}
+            </ToggleGroup.Root>
+
             <div className="settings-dialog-body">
-                <div className="setting">
-                    <h3>Tag Hover Highlight</h3>
-                    <p>Highlight games when hovering on a sidebar tag</p>
-                    <RadioGroup.Root
-                        defaultValue={settingsStore.tagHoverGameHighlight}
-                        className="rx-radio-group"
-                        onValueChange={(option) => settingsStore.setTagHoverGameHighlight(option)}
-                    >
-                        {Object.keys(TagHoverGameHighlightOptions).map((option) => {
-                            const optKey = `tagHoverGameHighlight-${option}`;
-                            return (
-                                <label htmlFor={optKey} key={optKey}>
-                                    <RadioGroup.Item value={option} id={optKey} />
-                                    {TagHoverGameHighlightOptions[option]}
-                                </label>
-                            );
-                        })}
-                    </RadioGroup.Root>
-                </div>
-
-                <div className="setting">
-                    <h3>Game Count Badge</h3>
-                    <p>Show a Game Counter next to each Tag in the Sidebar</p>
-                    <RadioGroup.Root
-                        defaultValue={settingsStore.tagGameCounterDisplay}
-                        className="rx-radio-group"
-                        onValueChange={(option) => settingsStore.setTagGameCounterDisplay(option)}
-                    >
-                        {Object.keys(TagGameCounterOptions).map((option) => {
-                            const optKey = `tagGameCounter-${option}`;
-                            return (
-                                <label htmlFor={optKey} key={optKey}>
-                                    <RadioGroup.Item value={option} id={optKey} />
-                                    {TagGameCounterOptions[option]}
-                                </label>
-                            );
-                        })}
-                    </RadioGroup.Root>
-                </div>
-
-                <div className="setting">
-                    <h3>Obscure Game Platform Actions</h3>
-                    <p>
-                        In a Game Page, hide the &apos;Play&apos; and &apos;Store Page&apos; buttons
-                        unless cover art is hovered on
-                    </p>
-                    <RadioGroup.Root
-                        defaultValue={settingsStore.hideGameStoreButtons}
-                        className="rx-radio-group"
-                        onValueChange={(option) => settingsStore.setHideGameStoreButtons(option)}
-                    >
-                        {Object.keys(HideGameStoreButtonsOptions).map((option) => {
-                            const optKey = `hideGameStoreButtons-${option}`;
-                            return (
-                                <label htmlFor={optKey} key={optKey}>
-                                    <RadioGroup.Item value={option} id={optKey} />
-                                    {HideGameStoreButtonsOptions[option]}
-                                </label>
-                            );
-                        })}
-                    </RadioGroup.Root>
-                </div>
-
-                <div className="setting">
-                    <h3>
-                        Show Explicit Content{" "}
-                        <InfoIcon message="Only affects games whose main content is explicit sexual material. Games with general mature themes, violence, or occasional nudity aren't hidden by this." />
-                    </h3>
-                    <p>Include explicit/adult-only games when searching for a game to add</p>
-                    <RadioGroup.Root
-                        defaultValue={settingsStore.showMatureContent}
-                        className="rx-radio-group"
-                        onValueChange={(option) => settingsStore.setShowMatureContent(option)}
-                    >
-                        {Object.keys(ShowMatureContentOptions).map((option) => {
-                            const optKey = `showMatureContent-${option}`;
-                            return (
-                                <label htmlFor={optKey} key={optKey}>
-                                    <RadioGroup.Item value={option} id={optKey} />
-                                    {ShowMatureContentOptions[option]}
-                                </label>
-                            );
-                        })}
-                    </RadioGroup.Root>
-                </div>
-
-                <div className="setting">
-                    <h3>Friend Icons</h3>
-                    <p>Show friend avatars in the Friends sidebar and a game&apos;s tag list</p>
-                    <RadioGroup.Root
-                        defaultValue={settingsStore.friendIconDisplay}
-                        className="rx-radio-group"
-                        onValueChange={(option) => settingsStore.setFriendIconDisplay(option)}
-                    >
-                        {Object.keys(FriendIconDisplayOptions).map((option) => {
-                            const optKey = `friendIconDisplay-${option}`;
-                            return (
-                                <label htmlFor={optKey} key={optKey}>
-                                    <RadioGroup.Item value={option} id={optKey} />
-                                    {FriendIconDisplayOptions[option]}
-                                </label>
-                            );
-                        })}
-                    </RadioGroup.Root>
-                </div>
-
-                <div className="setting">
-                    <h3>Default Filter State</h3>
-                    <p>Set current filters as the default state to show on load</p>
-                    <div className="default-filters-buttons">
-                        <Button
-                            variant="secondary"
-                            onClick={() => filterStore.saveDefaultFilters()}
-                        >
-                            Set as Default
-                        </Button>
-                        <Button
-                            variant="secondary"
-                            onClick={() => filterStore.resetDefaultFilters()}
-                        >
-                            Reset
-                        </Button>
-                    </div>
-                </div>
+                <ActiveTabComponent />
             </div>
 
             <div className="rx-dialog-footer">
@@ -163,4 +55,4 @@ export const SettingsDialog = ({ open, closeDialog }) => {
             </div>
         </DialogBase>
     );
-};
+});

--- a/src/components/Dialogs/SettingsDialog/FiltersTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/FiltersTab.jsx
@@ -1,0 +1,47 @@
+import { observer } from "mobx-react-lite";
+import { Button, InfoIcon, RadioSetting, Setting } from "@/components";
+import {
+    ShowMatureContentOptions,
+    SettingsDefaults,
+    useFilterStore,
+    useSettingsStore,
+} from "@/stores";
+
+export const FiltersTab = observer(() => {
+    const settingsStore = useSettingsStore();
+    const filterStore = useFilterStore();
+
+    return (
+        <>
+            <Setting
+                title="Show Explicit Content"
+                titleExtra={
+                    <InfoIcon message="Only affects games whose main content is explicit sexual material. Games with general mature themes, violence, or occasional nudity aren't hidden by this." />
+                }
+                description="Include explicit/adult-only games when searching for a game to add"
+                defaultValue={ShowMatureContentOptions[SettingsDefaults.showMatureContent]}
+            >
+                <RadioSetting
+                    name="showMatureContent"
+                    value={settingsStore.showMatureContent}
+                    options={ShowMatureContentOptions}
+                    onChange={(option) => settingsStore.setShowMatureContent(option)}
+                />
+            </Setting>
+
+            <Setting
+                title="Default Filter State"
+                description="Set current filters as the default state to show on load"
+            >
+                <div className="default-filters-buttons">
+                    <Button variant="secondary" onClick={() => filterStore.saveDefaultFilters()}>
+                        Set as Default
+                    </Button>
+                    <Button variant="secondary" onClick={() => filterStore.resetDefaultFilters()}>
+                        Reset
+                    </Button>
+                </div>
+            </Setting>
+        </>
+    );
+});

--- a/src/components/Dialogs/SettingsDialog/FiltersTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/FiltersTab.jsx
@@ -19,7 +19,10 @@ export const FiltersTab = observer(() => {
                     <InfoIcon message="Only affects games whose main content is explicit sexual material. Games with general mature themes, violence, or occasional nudity aren't hidden by this." />
                 }
                 description="Include explicit/adult-only games when searching for a game to add"
-                defaultValue={ShowMatureContentOptions[SettingsDefaults.showMatureContent]}
+                isDefault={settingsStore.showMatureContent === SettingsDefaults.showMatureContent}
+                onReset={() =>
+                    settingsStore.setShowMatureContent(SettingsDefaults.showMatureContent)
+                }
             >
                 <RadioSetting
                     name="showMatureContent"

--- a/src/components/Dialogs/SettingsDialog/GamesGridTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/GamesGridTab.jsx
@@ -1,0 +1,58 @@
+import { observer } from "mobx-react-lite";
+import { RadioSetting, Setting, Slider } from "@/components";
+import {
+    GamesGridDensityOptions,
+    GamesGridCardWidthRange,
+    HideGameStoreButtonsOptions,
+    SettingsDefaults,
+    useSettingsStore,
+} from "@/stores";
+
+export const GamesGridTab = observer(() => {
+    const settingsStore = useSettingsStore();
+
+    return (
+        <>
+            <Setting
+                title="Game Card Size"
+                description="Width of game cards in the grid, more or fewer fit per row automatically"
+                defaultValue={`${SettingsDefaults.gamesGridCardWidth}px`}
+            >
+                <Slider
+                    min={GamesGridCardWidthRange.min}
+                    max={GamesGridCardWidthRange.max}
+                    step={GamesGridCardWidthRange.step}
+                    value={settingsStore.gamesGridCardWidth}
+                    onChange={(value) => settingsStore.setGamesGridCardWidth(value)}
+                    formatValue={(v) => `${v}px`}
+                />
+            </Setting>
+
+            <Setting
+                title="Grid Spacing"
+                description="Padding and gaps between cards in the games grid"
+                defaultValue={GamesGridDensityOptions[SettingsDefaults.gamesGridDensity]}
+            >
+                <RadioSetting
+                    name="gamesGridDensity"
+                    value={settingsStore.gamesGridDensity}
+                    options={GamesGridDensityOptions}
+                    onChange={(option) => settingsStore.setGamesGridDensity(option)}
+                />
+            </Setting>
+
+            <Setting
+                title="Obscure Game Platform Actions"
+                description="In a Game Page, hide the 'Play' and 'Store Page' buttons unless cover art is hovered on"
+                defaultValue={HideGameStoreButtonsOptions[SettingsDefaults.hideGameStoreButtons]}
+            >
+                <RadioSetting
+                    name="hideGameStoreButtons"
+                    value={settingsStore.hideGameStoreButtons}
+                    options={HideGameStoreButtonsOptions}
+                    onChange={(option) => settingsStore.setHideGameStoreButtons(option)}
+                />
+            </Setting>
+        </>
+    );
+});

--- a/src/components/Dialogs/SettingsDialog/GamesGridTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/GamesGridTab.jsx
@@ -16,7 +16,10 @@ export const GamesGridTab = observer(() => {
             <Setting
                 title="Game Card Size"
                 description="Width of game cards in the grid, more or fewer fit per row automatically"
-                defaultValue={`${SettingsDefaults.gamesGridCardWidth}px`}
+                isDefault={settingsStore.gamesGridCardWidth === SettingsDefaults.gamesGridCardWidth}
+                onReset={() =>
+                    settingsStore.setGamesGridCardWidth(SettingsDefaults.gamesGridCardWidth)
+                }
             >
                 <Slider
                     min={GamesGridCardWidthRange.min}
@@ -31,7 +34,8 @@ export const GamesGridTab = observer(() => {
             <Setting
                 title="Grid Spacing"
                 description="Padding and gaps between cards in the games grid"
-                defaultValue={GamesGridDensityOptions[SettingsDefaults.gamesGridDensity]}
+                isDefault={settingsStore.gamesGridDensity === SettingsDefaults.gamesGridDensity}
+                onReset={() => settingsStore.setGamesGridDensity(SettingsDefaults.gamesGridDensity)}
             >
                 <RadioSetting
                     name="gamesGridDensity"
@@ -44,7 +48,12 @@ export const GamesGridTab = observer(() => {
             <Setting
                 title="Obscure Game Platform Actions"
                 description="In a Game Page, hide the 'Play' and 'Store Page' buttons unless cover art is hovered on"
-                defaultValue={HideGameStoreButtonsOptions[SettingsDefaults.hideGameStoreButtons]}
+                isDefault={
+                    settingsStore.hideGameStoreButtons === SettingsDefaults.hideGameStoreButtons
+                }
+                onReset={() =>
+                    settingsStore.setHideGameStoreButtons(SettingsDefaults.hideGameStoreButtons)
+                }
             >
                 <RadioSetting
                     name="hideGameStoreButtons"

--- a/src/components/Dialogs/SettingsDialog/SidebarTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/SidebarTab.jsx
@@ -1,0 +1,56 @@
+import { observer } from "mobx-react-lite";
+import { RadioSetting, Setting } from "@/components";
+import {
+    TagHoverGameHighlightOptions,
+    TagGameCounterOptions,
+    FriendIconDisplayOptions,
+    SettingsDefaults,
+    useSettingsStore,
+} from "@/stores";
+
+export const SidebarTab = observer(() => {
+    const settingsStore = useSettingsStore();
+
+    return (
+        <>
+            <Setting
+                title="Tag Hover Highlight"
+                description="Highlight games when hovering on a sidebar tag"
+                defaultValue={TagHoverGameHighlightOptions[SettingsDefaults.tagHoverGameHighlight]}
+            >
+                <RadioSetting
+                    name="tagHoverGameHighlight"
+                    value={settingsStore.tagHoverGameHighlight}
+                    options={TagHoverGameHighlightOptions}
+                    onChange={(option) => settingsStore.setTagHoverGameHighlight(option)}
+                />
+            </Setting>
+
+            <Setting
+                title="Game Count Badge"
+                description="Show a Game Counter next to each Tag in the Sidebar"
+                defaultValue={TagGameCounterOptions[SettingsDefaults.tagGameCounterDisplay]}
+            >
+                <RadioSetting
+                    name="tagGameCounter"
+                    value={settingsStore.tagGameCounterDisplay}
+                    options={TagGameCounterOptions}
+                    onChange={(option) => settingsStore.setTagGameCounterDisplay(option)}
+                />
+            </Setting>
+
+            <Setting
+                title="Friend Icons"
+                description="Show friend avatars in the Friends sidebar and a game's tag list"
+                defaultValue={FriendIconDisplayOptions[SettingsDefaults.friendIconDisplay]}
+            >
+                <RadioSetting
+                    name="friendIconDisplay"
+                    value={settingsStore.friendIconDisplay}
+                    options={FriendIconDisplayOptions}
+                    onChange={(option) => settingsStore.setFriendIconDisplay(option)}
+                />
+            </Setting>
+        </>
+    );
+});

--- a/src/components/Dialogs/SettingsDialog/SidebarTab.jsx
+++ b/src/components/Dialogs/SettingsDialog/SidebarTab.jsx
@@ -16,7 +16,12 @@ export const SidebarTab = observer(() => {
             <Setting
                 title="Tag Hover Highlight"
                 description="Highlight games when hovering on a sidebar tag"
-                defaultValue={TagHoverGameHighlightOptions[SettingsDefaults.tagHoverGameHighlight]}
+                isDefault={
+                    settingsStore.tagHoverGameHighlight === SettingsDefaults.tagHoverGameHighlight
+                }
+                onReset={() =>
+                    settingsStore.setTagHoverGameHighlight(SettingsDefaults.tagHoverGameHighlight)
+                }
             >
                 <RadioSetting
                     name="tagHoverGameHighlight"
@@ -29,7 +34,12 @@ export const SidebarTab = observer(() => {
             <Setting
                 title="Game Count Badge"
                 description="Show a Game Counter next to each Tag in the Sidebar"
-                defaultValue={TagGameCounterOptions[SettingsDefaults.tagGameCounterDisplay]}
+                isDefault={
+                    settingsStore.tagGameCounterDisplay === SettingsDefaults.tagGameCounterDisplay
+                }
+                onReset={() =>
+                    settingsStore.setTagGameCounterDisplay(SettingsDefaults.tagGameCounterDisplay)
+                }
             >
                 <RadioSetting
                     name="tagGameCounter"
@@ -42,7 +52,10 @@ export const SidebarTab = observer(() => {
             <Setting
                 title="Friend Icons"
                 description="Show friend avatars in the Friends sidebar and a game's tag list"
-                defaultValue={FriendIconDisplayOptions[SettingsDefaults.friendIconDisplay]}
+                isDefault={settingsStore.friendIconDisplay === SettingsDefaults.friendIconDisplay}
+                onReset={() =>
+                    settingsStore.setFriendIconDisplay(SettingsDefaults.friendIconDisplay)
+                }
             >
                 <RadioSetting
                     name="friendIconDisplay"

--- a/src/components/GameGrid.css
+++ b/src/components/GameGrid.css
@@ -2,16 +2,23 @@
     width: 100%;
     overflow-y: auto;
     scrollbar-gutter: stable both-edges;
-    padding: 30px calc(30px - var(--scrollbar-width));
+    padding: var(--game-grid-container-padding)
+        calc(var(--game-grid-container-padding) - var(--scrollbar-width));
+
+    &.density-compact {
+        --game-grid-gap: 10px;
+        --game-grid-row-gap: 14px;
+        --game-grid-container-padding: 16px;
+    }
 }
 .games-grid {
     width: 100%;
     display: grid;
     grid-auto-flow: row;
     justify-content: space-between;
-    column-gap: 20px;
+    column-gap: var(--game-grid-gap);
     /* column-gap is the minimum, actual gap determined by space-between */
-    row-gap: 30px;
+    row-gap: var(--game-grid-row-gap);
     grid-template-columns: repeat(auto-fit, var(--game-card-width));
 }
 

--- a/src/components/GameGrid.jsx
+++ b/src/components/GameGrid.jsx
@@ -107,6 +107,7 @@ function EmptyGridPlaceholder() {
 
 export const GamesGrid = observer(() => {
     const { filteredGames } = useFilterStore();
+    const { gamesGridCardWidth, gamesGridDensity } = useSettingsStore();
 
     // useEffect to update the grid justification if there aren't enough items to fill the row
     const gridRef = useRef(null);
@@ -123,11 +124,18 @@ export const GamesGrid = observer(() => {
 
         updateGridJustification();
         window.addEventListener("resize", updateGridJustification);
-    }, [filteredGames]);
+        return () => window.removeEventListener("resize", updateGridJustification);
+        // card size/density change how games wrap into rows, so it needs rechecking too
+    }, [filteredGames, gamesGridCardWidth, gamesGridDensity]);
 
+    const densityClass = gamesGridDensity === "compact" ? " density-compact" : "";
     return (
-        <div className="games-grid-container">
-            <div className="games-grid" ref={gridRef}>
+        <div className={"games-grid-container" + densityClass}>
+            <div
+                className="games-grid"
+                ref={gridRef}
+                style={{ "--game-card-width": `${gamesGridCardWidth}px` }}
+            >
                 {filteredGames.map((game, index) => (
                     <GameCard game={game} key={index + " " + game.id} />
                 ))}

--- a/src/components/GameGrid.jsx
+++ b/src/components/GameGrid.jsx
@@ -31,8 +31,9 @@ const GameCard = observer(({ game }) => {
         else classes.push("doesnt-have-dragged-tag");
     }
     if (hoverTagSetting !== "none" && hoveredTag) {
-        if (hoverTagSetting === "highlight" && game.hasTag(hoveredTag)) classes.push("highlight");
-        else if (hoverTagSetting === "darken" && !game.hasTag(hoveredTag)) classes.push("darken");
+        const qualifies = filterStore.doesGameQualifyForTag(game, hoveredTag);
+        if (hoverTagSetting === "highlight" && qualifies) classes.push("highlight");
+        else if (hoverTagSetting === "darken" && !qualifies) classes.push("darken");
     }
     if (draggedOver) classes.push("dragged-over");
 

--- a/src/components/common/LabelBadge.css
+++ b/src/components/common/LabelBadge.css
@@ -1,0 +1,6 @@
+.label-badge {
+    margin-left: 6px;
+    font-weight: normal;
+    font-size: 12px;
+    color: var(--pf-fg-700);
+}

--- a/src/components/common/LabelBadge.jsx
+++ b/src/components/common/LabelBadge.jsx
@@ -1,0 +1,10 @@
+import "./LabelBadge.css";
+
+/**
+ * An annotation that is set next to a field label like "Icon URL (optional)".
+ * Defaults to "optional", pass children to reuse it for a different annotation later.
+ * @param {{ children?: React.ReactNode }} props
+ */
+export function LabelBadge({ children = "optional" }) {
+    return <span className="label-badge">({children})</span>;
+}

--- a/src/components/common/RadioSetting.jsx
+++ b/src/components/common/RadioSetting.jsx
@@ -2,7 +2,7 @@ import * as RadioGroup from "@radix-ui/react-radio-group";
 
 export function RadioSetting({ name, value, options, onChange }) {
     return (
-        <RadioGroup.Root defaultValue={value} className="rx-radio-group" onValueChange={onChange}>
+        <RadioGroup.Root value={value} className="rx-radio-group" onValueChange={onChange}>
             {Object.keys(options).map((option) => {
                 const optKey = `${name}-${option}`;
                 return (

--- a/src/components/common/RadioSetting.jsx
+++ b/src/components/common/RadioSetting.jsx
@@ -1,0 +1,17 @@
+import * as RadioGroup from "@radix-ui/react-radio-group";
+
+export function RadioSetting({ name, value, options, onChange }) {
+    return (
+        <RadioGroup.Root defaultValue={value} className="rx-radio-group" onValueChange={onChange}>
+            {Object.keys(options).map((option) => {
+                const optKey = `${name}-${option}`;
+                return (
+                    <label htmlFor={optKey} key={optKey}>
+                        <RadioGroup.Item value={option} id={optKey} />
+                        {options[option]}
+                    </label>
+                );
+            })}
+        </RadioGroup.Root>
+    );
+}

--- a/src/components/common/Setting.css
+++ b/src/components/common/Setting.css
@@ -1,0 +1,25 @@
+.setting {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    gap: 4px;
+
+    h3 {
+        font-size: 16px;
+        line-height: 1;
+        font-weight: 500;
+        color: #f2f2f2;
+    }
+    p {
+        font-size: 14px;
+        color: var(--pf-fg-400);
+    }
+    .setting-default {
+        font-size: 12px;
+        font-style: italic;
+        color: var(--pf-fg-700);
+    }
+    & > *:not(h3) {
+        margin-left: 8px;
+    }
+}

--- a/src/components/common/Setting.css
+++ b/src/components/common/Setting.css
@@ -10,14 +10,24 @@
         font-weight: 500;
         color: #f2f2f2;
     }
+    .setting-reset {
+        --icon-size: 26px;
+        display: inline-flex;
+        vertical-align: middle;
+        margin-left: 6px;
+        font-size: 20px;
+
+        svg {
+            transform: scaleX(-1);
+        }
+
+        &.setting-reset-hidden {
+            visibility: hidden; /* so it doesn't nudge */
+        }
+    }
     p {
         font-size: 14px;
         color: var(--pf-fg-400);
-    }
-    .setting-default {
-        font-size: 12px;
-        font-style: italic;
-        color: var(--pf-fg-700);
     }
     & > *:not(h3) {
         margin-left: 8px;

--- a/src/components/common/Setting.css
+++ b/src/components/common/Setting.css
@@ -16,6 +16,7 @@
         vertical-align: middle;
         margin-left: 6px;
         font-size: 20px;
+        transition: none;
 
         svg {
             transform: scaleX(-1);

--- a/src/components/common/Setting.jsx
+++ b/src/components/common/Setting.jsx
@@ -1,0 +1,30 @@
+import "./Setting.css";
+
+/**
+ * A settings row, a title with optional extra content next to it (e.g. an InfoIcon),
+ * a description, an optional "Default: X" annotation, and the setting's own control
+ * passed as children.
+ * @param {{
+ *   title: React.ReactNode,
+ *   titleExtra?: React.ReactNode,
+ *   description?: React.ReactNode,
+ *   defaultValue?: React.ReactNode,
+ *   children?: React.ReactNode,
+ * }} props
+ * @returns {JSX.Element}
+ */
+export function Setting({ title, titleExtra, description, defaultValue, children }) {
+    return (
+        <div className="setting">
+            <h3>
+                {title}
+                {titleExtra && <> {titleExtra}</>}
+            </h3>
+            {description && <p>{description}</p>}
+            {defaultValue !== undefined && (
+                <p className="setting-default">Default: {defaultValue}</p>
+            )}
+            {children}
+        </div>
+    );
+}

--- a/src/components/common/Setting.jsx
+++ b/src/components/common/Setting.jsx
@@ -1,29 +1,42 @@
+import { MdRefresh } from "react-icons/md";
+import { IconButton, SimpleTooltip } from "@/components";
 import "./Setting.css";
 
 /**
  * A settings row, a title with optional extra content next to it (e.g. an InfoIcon),
- * a description, an optional "Default: X" annotation, and the setting's own control
- * passed as children.
+ * a description, and the setting's own control passed as children. 
+ * 
+ * isDefault - Boolean that checks if its currently default, false shows the Reset Icon.
+ * 
+ * onReset - Clicking the Rest icon will call this callback. Only available if isDefault = false.
  * @param {{
  *   title: React.ReactNode,
  *   titleExtra?: React.ReactNode,
  *   description?: React.ReactNode,
- *   defaultValue?: React.ReactNode,
+ *   isDefault?: boolean,
+ *   onReset?: () => void,
  *   children?: React.ReactNode,
  * }} props
  * @returns {JSX.Element}
  */
-export function Setting({ title, titleExtra, description, defaultValue, children }) {
+export function Setting({ title, titleExtra, description, isDefault = true, onReset, children }) {
     return (
         <div className="setting">
             <h3>
                 {title}
                 {titleExtra && <> {titleExtra}</>}
+                {onReset && (
+                    <SimpleTooltip message="Restore default">
+                        <IconButton
+                            className={`setting-reset${isDefault ? " setting-reset-hidden" : ""}`}
+                            icon={<MdRefresh />}
+                            aria-label="Restore default"
+                            onClick={onReset}
+                        />
+                    </SimpleTooltip>
+                )}
             </h3>
             {description && <p>{description}</p>}
-            {defaultValue !== undefined && (
-                <p className="setting-default">Default: {defaultValue}</p>
-            )}
             {children}
         </div>
     );

--- a/src/components/common/Slider.css
+++ b/src/components/common/Slider.css
@@ -1,0 +1,57 @@
+.slider-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    max-width: 320px;
+}
+
+.slider-value {
+    min-width: 40px;
+    text-align: right;
+    font-size: 14px;
+    color: var(--pf-fg-300);
+    font-variant-numeric: tabular-nums;
+}
+
+.rx-slider {
+    flex: 1;
+    -webkit-appearance: none;
+    appearance: none;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--pf-bg-100);
+    outline: none;
+
+    &::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: var(--pf-btn-primary);
+        border: 2px solid var(--pf-bg-900);
+        cursor: pointer;
+        transition: background-color 0.15s ease;
+    }
+    &:hover::-webkit-slider-thumb {
+        background: var(--pf-btn-primary-hover);
+    }
+
+    &::-moz-range-track {
+        height: 4px;
+        border-radius: 2px;
+        background: var(--pf-bg-100);
+    }
+    &::-moz-range-thumb {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: var(--pf-btn-primary);
+        border: 2px solid var(--pf-bg-900);
+        cursor: pointer;
+    }
+    &:hover::-moz-range-thumb {
+        background: var(--pf-btn-primary-hover);
+    }
+}

--- a/src/components/common/Slider.jsx
+++ b/src/components/common/Slider.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import "./Slider.css";
+
+/**
+ * A themed range input with a live value readout next to it.
+ *
+ * The displayed value/thumb track every drag tick, but the `onChange` only fires once the interaction
+ * actually ends, a range input's onChange fires continuously while dragging, and callers typically 
+ * persist/sync on change, so firing on every tick would otherwise spam that.
+ *
+ * @param {{
+ *   value: number,
+ *   min: number,
+ *   max: number,
+ *   step?: number,
+ *   onChange: (value: string) => void,
+ *   formatValue?: (value: number) => React.ReactNode,
+ * }} props
+ * @returns {JSX.Element}
+ */
+export function Slider({ value, min, max, step = 1, onChange, formatValue = (v) => v }) {
+    const [liveValue, setLiveValue] = useState(value);
+    // Stay in sync if `value` changes for a reason other than our own commit below like loaded from storage
+    useEffect(() => setLiveValue(value), [value]);
+
+    const commit = () => onChange(liveValue);
+
+    return (
+        <div className="slider-row">
+            <input
+                type="range"
+                className="rx-slider"
+                min={min}
+                max={max}
+                step={step}
+                value={liveValue}
+                onChange={(e) => setLiveValue(Number(e.target.value))}
+                onPointerUp={commit}
+                onKeyUp={commit}
+                onBlur={commit}
+            />
+            <span className="slider-value">{formatValue(liveValue)}</span>
+        </div>
+    );
+}

--- a/src/components/common/Slider.jsx
+++ b/src/components/common/Slider.jsx
@@ -5,7 +5,7 @@ import "./Slider.css";
  * A themed range input with a live value readout next to it.
  *
  * The displayed value/thumb track every drag tick, but the `onChange` only fires once the interaction
- * actually ends, a range input's onChange fires continuously while dragging, and callers typically 
+ * actually ends, a range input's onChange fires continuously while dragging, and callers typically
  * persist/sync on change, so firing on every tick would otherwise spam that.
  *
  * @param {{
@@ -23,8 +23,7 @@ export function Slider({ value, min, max, step = 1, onChange, formatValue = (v) 
     // Stay in sync if `value` changes for a reason other than our own commit below like loaded from storage
     useEffect(() => setLiveValue(value), [value]);
 
-    const commit = () => onChange(liveValue);
-
+    const commit = (e) => onChange(e.target.value);
     return (
         <div className="slider-row">
             <input
@@ -34,10 +33,10 @@ export function Slider({ value, min, max, step = 1, onChange, formatValue = (v) 
                 max={max}
                 step={step}
                 value={liveValue}
-                onChange={(e) => setLiveValue(Number(e.target.value))}
+                onChange={commit}
                 onPointerUp={commit}
-                onKeyUp={commit}
                 onBlur={commit}
+                onKeyUp={commit}
             />
             <span className="slider-value">{formatValue(liveValue)}</span>
         </div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -11,6 +11,7 @@ export { ArrowToFeature } from "./common/ArrowToFeature.jsx";
 export { FriendAvatar } from "./common/FriendAvatar.jsx";
 export { Setting } from "./common/Setting.jsx";
 export { Slider } from "./common/Slider.jsx";
+export { RadioSetting } from "./common/RadioSetting.jsx";
 export { GamesGrid } from "./GameGrid.jsx";
 export { SidebarTagButton } from "./TagButton.jsx";
 export { SidebarTagButtonGroup } from "./TagButtonGroup.jsx";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,8 @@ export { SimpleTooltip } from "./common/SimpleTooltip.jsx";
 export { InfoIcon } from "./common/InfoIcon.jsx";
 export { ArrowToFeature } from "./common/ArrowToFeature.jsx";
 export { FriendAvatar } from "./common/FriendAvatar.jsx";
+export { Setting } from "./common/Setting.jsx";
+export { Slider } from "./common/Slider.jsx";
 export { GamesGrid } from "./GameGrid.jsx";
 export { SidebarTagButton } from "./TagButton.jsx";
 export { SidebarTagButtonGroup } from "./TagButtonGroup.jsx";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,6 +7,7 @@ export { ScrollView } from "./common/ScrollView.jsx";
 export { Spinner } from "./common/Spinner.jsx";
 export { SimpleTooltip } from "./common/SimpleTooltip.jsx";
 export { InfoIcon } from "./common/InfoIcon.jsx";
+export { LabelBadge } from "./common/LabelBadge.jsx";
 export { ArrowToFeature } from "./common/ArrowToFeature.jsx";
 export { FriendAvatar } from "./common/FriendAvatar.jsx";
 export { Setting } from "./common/Setting.jsx";

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
     --app-header-element-height: 36px;
     --ui-card-width: 275px;
     --ui-card-border-radius: 20px;
-    --game-card-width: 210px; /* for the game cards in the grid */
+    --game-card-width: 210px; /* a default value, overridden by a setting, for game cards in the grid.*/
     --game-grid-gap: 20px;
     --game-grid-row-gap: 30px;
     --game-grid-container-padding: 30px;

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,9 @@
     --ui-card-width: 275px;
     --ui-card-border-radius: 20px;
     --game-card-width: 210px; /* for the game cards in the grid */
+    --game-grid-gap: 20px;
+    --game-grid-row-gap: 30px;
+    --game-grid-container-padding: 30px;
     --game-card-border-radius: 4px;
     --icon-size: 30px; /* for icon buttons like ⋮ or + */
     --dialog-fade-duration: 250ms;

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -209,6 +209,7 @@ export class DataStore {
         reaction(
             () => JSON.stringify(globalSettingsStore),
             () => this.syncBoardKeyToBackend(storageKeys.settings, globalSettingsStore),
+            { delay: 2000 },
         );
     }
 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -209,7 +209,7 @@ export class DataStore {
         reaction(
             () => JSON.stringify(globalSettingsStore),
             () => this.syncBoardKeyToBackend(storageKeys.settings, globalSettingsStore),
-            { delay: 2000 },
+            { delay: 1000 },
         );
     }
 

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -6,8 +6,8 @@ import { tagTypes } from "@/models";
 export const settingsStorageKey = "settings";
 
 export const TagHoverGameHighlightOptions = {
-    highlight: "Highlight",
     darken: "Darken the rest",
+    highlight: "Highlight",
     none: "None",
 };
 export const TagFilterLogicOptions = {
@@ -33,22 +33,37 @@ export const TagGameCounterOptions = {
     none: "None",
 };
 export const HideGameStoreButtonsOptions = {
-    on: "On",
     off: "Off",
+    on: "On",
 };
 export const ShowMatureContentOptions = {
-    on: "On",
     off: "Off",
+    on: "On",
 };
 export const FriendIconDisplayOptions = {
-    hide: "Hide",
     hideMissing: "Hide Missing",
+    hide: "Hide All",
     showAll: "Show All",
+};
+export const GamesGridDensityOptions = {
+    simple: "Simple",
+    compact: "Compact",
+};
+export const GamesGridCardWidthRange = { min: 140, max: 320, step: 10 };
+
+export const SettingsDefaults = {
+    tagHoverGameHighlight: "darken",
+    tagGameCounterDisplay: "countFiltered",
+    friendIconDisplay: "hideMissing",
+    gamesGridDensity: "simple",
+    gamesGridCardWidth: 210,
+    hideGameStoreButtons: "off",
+    showMatureContent: "off",
 };
 
 class SettingsStore {
     // Default values, overridden by settings loaded from storage
-    tagHoverGameHighlight = "darken";
+    tagHoverGameHighlight = SettingsDefaults.tagHoverGameHighlight;
     tagFilterLogic = {
         [tagTypes.friend]: "AND",
         [tagTypes.category]: "OR",
@@ -66,10 +81,12 @@ class SettingsStore {
     };
     gameSortMethod = "title";
     gameSortDirection = "asc";
-    tagGameCounterDisplay = "countFiltered";
-    hideGameStoreButtons = "off";
-    showMatureContent = "off";
-    friendIconDisplay = "hideMissing";
+    tagGameCounterDisplay = SettingsDefaults.tagGameCounterDisplay;
+    hideGameStoreButtons = SettingsDefaults.hideGameStoreButtons;
+    showMatureContent = SettingsDefaults.showMatureContent;
+    friendIconDisplay = SettingsDefaults.friendIconDisplay;
+    gamesGridDensity = SettingsDefaults.gamesGridDensity; // spacing between game cards
+    gamesGridCardWidth = SettingsDefaults.gamesGridCardWidth; // in px
 
     constructor() {
         makeAutoObservable(this);
@@ -117,6 +134,16 @@ class SettingsStore {
     setFriendIconDisplay(option) {
         if (FriendIconDisplayOptions[option]) this.friendIconDisplay = option;
         else console.warn(`Invalid FriendIconDisplay option: ${option}`);
+    }
+
+    setGamesGridDensity(option) {
+        if (GamesGridDensityOptions[option]) this.gamesGridDensity = option;
+        else console.warn(`Invalid GamesGridDensity option: ${option}`);
+    }
+
+    setGamesGridCardWidth(width) {
+        const { min, max } = GamesGridCardWidthRange;
+        this.gamesGridCardWidth = Math.min(max, Math.max(min, Number(width)));
     }
 }
 

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -153,9 +153,3 @@ const settingsStore = new SettingsStore(); // After creation, settings are popul
 const SettingsStoreContext = createContext(settingsStore);
 export const useSettingsStore = () => useContext(SettingsStoreContext);
 export const globalSettingsStore = settingsStore;
-
-// whenever settings are changed, auto-save
-reaction(
-    () => JSON.stringify(settingsStore),
-    () => saveToStorage(settingsStorageKey, settingsStore),
-);

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -57,7 +57,7 @@ export const SettingsDefaults = {
     friendIconDisplay: "hideMissing",
     gamesGridDensity: "simple",
     gamesGridCardWidth: 210,
-    hideGameStoreButtons: "off",
+    hideGameStoreButtons: "on",
     showMatureContent: "off",
 };
 

--- a/src/styles/ui-elements.css
+++ b/src/styles/ui-elements.css
@@ -201,32 +201,6 @@ input[type="checkbox"] {
         list-style-position: inside;
     }
 
-    &.info {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        border: none;
-        width: fit-content;
-        border-left: 4px solid hsl(var(--hsl-base-btn-primary) 60%);
-        gap: 8px;
-        padding: 12px;
-
-        p {
-            color: var(--pf-fg-500);
-        }
-
-        .info-icon {
-            margin: 0;
-            height: 24px;
-            width: 24px;
-            font-size: 16px;
-            font-family: system-ui;
-            color: var(--pf-fg-link);
-            border: 2px solid var(--pf-fg-link);
-        }
-    }
     .link-like {
         font-weight: 500;
     }


### PR DESCRIPTION
This PR addresses a lot of issues that would happen when adding more settings that changes different things in the app, for that I've reworked and standarized the it into tabs, added "default: X"  value entry.

Additionally, users can now adjust the size of grid cards to fit their needs, including making it simple or compact. During that, I've taken the time to also sort out all settings, fix wording and making sure we are consistent, for example **all settings default is always first in the list*.

Should also be scalable, added Setting component that takes title, description, default value and a child that holds the setting.

In short:
* Setting components that handles each setting
* Game Card Size is adjustable, 210px and simple is default (exactly as is on `main`)
* Added Settings Tabs: Sidebar, Game Grid and Filters
* Setting dialog has a fixed size
* All settings have a "default" value in their description
* All settings options have been sorted for consistency, with default being first on the list.
* Friend Icons: Renamed "Hide" to "Hide All" for clarity.